### PR TITLE
Use package index on docs site

### DIFF
--- a/docs/azure/intro.md
+++ b/docs/azure/intro.md
@@ -23,7 +23,7 @@ This document provides an overview of key concepts and services .NET developers 
 
 **Managed services**: Azure provides some services where you provide data or information to Azure, and Azure's implementation takes the appropriate action. One example is Azure Blob Storage, where you provide files and Azure handles reading, writing, and persisting them.
 
-**Azure SDK for .NET**: Sometimes referred to as the **Azure libraries for .NET**, this collectively refers to the [NuGet packages](https://www.nuget.org/profiles/azure-sdk) you install in your project that provide various interactions and functionality with Azure services. These packages also include management libraries used to provision and administer the resources.
+**Azure SDK for .NET**: Sometimes referred to as the **Azure libraries for .NET**, this collectively refers to the [NuGet packages](packages.md) you install in your project that provide various interactions and functionality with Azure services. These packages also include management libraries used to provision and administer the resources.
 
 ## Choosing a hosting option
 


### PR DESCRIPTION
Lets use our package index package instead of a nuget query so we can guide people to the newer libraries.